### PR TITLE
feat(timestamp): add standardized timestamp format support

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -163,22 +163,19 @@ impl Logger {
 **Priority**: High
 **Estimated Effort**: Medium (1 week)
 
-### 2. Inconsistent Timestamp Formatting
+### 2. Inconsistent Timestamp Formatting ✅ RESOLVED
 
 **Issue**: Custom timestamp formats in log output are not validated or standardized, leading to parsing difficulties, inconsistent log analysis, and integration problems with log aggregation systems.
 
-**Location**: `src/formatter.rs:56`
+**Status**: **RESOLVED** - Implemented in `src/core/timestamp.rs`
 
-**Current Implementation**:
-```rust
-pub fn format_timestamp(&self, timestamp: &SystemTime) -> String {
-    // Basic ISO 8601 format, but not configurable or standardized
-    let datetime: DateTime<Utc> = (*timestamp).into();
-    datetime.format("%Y-%m-%d %H:%M:%S").to_string()
-}
-```
+**Solution Implemented**:
+- Added `TimestampFormat` enum with support for ISO 8601, RFC 3339, Unix timestamps, and custom formats
+- Added `FormatterConfig` struct for sharing formatting configuration
+- Updated all appenders (ConsoleAppender, FileAppender, RotatingFileAppender, JsonAppender) to support configurable timestamp formats
+- JSON output now supports both string and numeric timestamp formats based on configuration
 
-**Impact**:
+**Previous Impact** (now resolved):
 - Cannot customize timestamp format for different environments
 - Missing timezone information in some formats
 - Difficult to parse logs with automated tools
@@ -704,11 +701,11 @@ let logger = Logger::with_config(LoggerConfig {
 - [x] Test all overflow scenarios
 - [x] Add priority-based preservation (Critical logs never dropped)
 
-### Phase 2: Formatting and Standards (Sprint 2)
-- [ ] Add standard timestamp formats
-- [ ] Implement JSON output format
-- [ ] Add structured logging support
-- [ ] Update documentation
+### Phase 2: Formatting and Standards (Sprint 2) ✅ COMPLETED
+- [x] Add standard timestamp formats (TimestampFormat enum with Iso8601, Rfc3339, Unix variants)
+- [x] Implement JSON output format (JsonAppender with configurable timestamp)
+- [x] Add structured logging support (LogContext with FieldValue)
+- [x] Update documentation
 
 ### Phase 3: Production Features (Sprint 3)
 - [ ] Implement log rotation

--- a/src/appenders/console.rs
+++ b/src/appenders/console.rs
@@ -1,19 +1,59 @@
 //! Console appender implementation
 
-use crate::core::{Appender, LogEntry, LogLevel, Result};
+use crate::core::{Appender, LogEntry, LogLevel, Result, TimestampFormat};
 use colored::Colorize;
 
 pub struct ConsoleAppender {
     use_colors: bool,
+    timestamp_format: TimestampFormat,
 }
 
 impl ConsoleAppender {
     pub fn new() -> Self {
-        Self { use_colors: true }
+        Self {
+            use_colors: true,
+            timestamp_format: TimestampFormat::default(),
+        }
     }
 
     pub fn with_colors(use_colors: bool) -> Self {
-        Self { use_colors }
+        Self {
+            use_colors,
+            timestamp_format: TimestampFormat::default(),
+        }
+    }
+
+    /// Set the timestamp format for this appender
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rust_logger_system::appenders::ConsoleAppender;
+    /// use rust_logger_system::TimestampFormat;
+    ///
+    /// let appender = ConsoleAppender::new()
+    ///     .with_timestamp_format(TimestampFormat::Iso8601Micros);
+    /// ```
+    #[must_use]
+    pub fn with_timestamp_format(mut self, format: TimestampFormat) -> Self {
+        self.timestamp_format = format;
+        self
+    }
+
+    /// Set a custom timestamp format using a strftime-compatible format string
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rust_logger_system::appenders::ConsoleAppender;
+    ///
+    /// let appender = ConsoleAppender::new()
+    ///     .with_custom_timestamp("%d/%b/%Y:%H:%M:%S %z");
+    /// ```
+    #[must_use]
+    pub fn with_custom_timestamp(mut self, format_str: &str) -> Self {
+        self.timestamp_format = TimestampFormat::Custom(format_str.to_string());
+        self
     }
 }
 
@@ -26,14 +66,18 @@ impl Default for ConsoleAppender {
 impl Appender for ConsoleAppender {
     fn append(&mut self, entry: &LogEntry) -> Result<()> {
         let level_str = if self.use_colors {
-            format!("{:5}", entry.level.to_str()).color(entry.level.color_code()).to_string()
+            format!("{:5}", entry.level.to_str())
+                .color(entry.level.color_code())
+                .to_string()
         } else {
             format!("{:5}", entry.level.to_str())
         };
 
+        let timestamp_str = self.timestamp_format.format(&entry.timestamp);
+
         let output = format!(
             "[{}] [{}] {} - {}",
-            entry.timestamp.format("%Y-%m-%d %H:%M:%S%.3f"),
+            timestamp_str,
             level_str,
             entry.thread_name.as_ref().unwrap_or(&entry.thread_id),
             entry.message

--- a/src/appenders/file.rs
+++ b/src/appenders/file.rs
@@ -1,35 +1,65 @@
 //! File appender implementation
 
-use crate::core::{Appender, LogEntry, LoggerError, Result};
+use crate::core::{Appender, LogEntry, LoggerError, Result, TimestampFormat};
 use std::fs::{File, OpenOptions};
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 
 pub struct FileAppender {
     writer: Option<BufWriter<File>>,
+    timestamp_format: TimestampFormat,
 }
 
 impl FileAppender {
     pub fn new(path: impl Into<PathBuf>) -> Result<Self> {
         let path = path.into();
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)?;
+        let file = OpenOptions::new().create(true).append(true).open(&path)?;
         let writer = Some(BufWriter::new(file));
 
-        Ok(Self { writer })
+        Ok(Self {
+            writer,
+            timestamp_format: TimestampFormat::default(),
+        })
+    }
+
+    /// Set the timestamp format for this appender
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use rust_logger_system::appenders::FileAppender;
+    /// use rust_logger_system::TimestampFormat;
+    ///
+    /// let appender = FileAppender::new("/var/log/app.log")
+    ///     .unwrap()
+    ///     .with_timestamp_format(TimestampFormat::Rfc3339);
+    /// ```
+    #[must_use]
+    pub fn with_timestamp_format(mut self, format: TimestampFormat) -> Self {
+        self.timestamp_format = format;
+        self
+    }
+
+    /// Set a custom timestamp format using a strftime-compatible format string
+    #[must_use]
+    pub fn with_custom_timestamp(mut self, format_str: &str) -> Self {
+        self.timestamp_format = TimestampFormat::Custom(format_str.to_string());
+        self
     }
 }
 
 impl Appender for FileAppender {
     fn append(&mut self, entry: &LogEntry) -> Result<()> {
-        let writer = self.writer.as_mut()
+        let writer = self
+            .writer
+            .as_mut()
             .ok_or_else(|| LoggerError::writer("File writer not initialized"))?;
+
+        let timestamp_str = self.timestamp_format.format(&entry.timestamp);
 
         let mut output = format!(
             "[{}] [{:5}] [{}] {}",
-            entry.timestamp.format("%Y-%m-%d %H:%M:%S%.3f"),
+            timestamp_str,
             entry.level.to_str(),
             entry.thread_name.as_ref().unwrap_or(&entry.thread_id),
             entry.message

--- a/src/appenders/json.rs
+++ b/src/appenders/json.rs
@@ -1,6 +1,6 @@
 //! JSON appender for structured logging
 
-use crate::core::{Appender, LogEntry, Result, StructuredLogEntry};
+use crate::core::{Appender, LogEntry, Result, TimestampFormat};
 use std::fs::{File, OpenOptions};
 use std::io::{BufWriter, Write};
 use std::path::Path;
@@ -12,46 +12,75 @@ use std::path::Path;
 pub struct JsonAppender {
     writer: BufWriter<File>,
     pretty: bool,
+    timestamp_format: TimestampFormat,
 }
 
 impl JsonAppender {
     /// Create a new JSON appender
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)?;
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
 
         Ok(Self {
             writer: BufWriter::new(file),
             pretty: false,
+            timestamp_format: TimestampFormat::default(),
         })
     }
 
     /// Create a new JSON appender with pretty printing
     pub fn new_pretty<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)?;
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
 
         Ok(Self {
             writer: BufWriter::new(file),
             pretty: true,
+            timestamp_format: TimestampFormat::default(),
         })
     }
 
-    /// Convert LogEntry to StructuredLogEntry
-    fn to_structured(&self, entry: &LogEntry) -> StructuredLogEntry {
-        let mut structured = StructuredLogEntry::new(entry.level, &entry.message);
+    /// Set the timestamp format for this appender
+    ///
+    /// For JSON output:
+    /// - Numeric formats (Unix, UnixMillis, UnixMicros) output a number
+    /// - String formats (Iso8601, Rfc3339, Custom) output a string
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use rust_logger_system::appenders::JsonAppender;
+    /// use rust_logger_system::TimestampFormat;
+    ///
+    /// let appender = JsonAppender::new("/var/log/app.jsonl")
+    ///     .unwrap()
+    ///     .with_timestamp_format(TimestampFormat::Iso8601);
+    /// ```
+    #[must_use]
+    pub fn with_timestamp_format(mut self, format: TimestampFormat) -> Self {
+        self.timestamp_format = format;
+        self
+    }
 
-        // Add context if present
-        if let Some(context) = &entry.context {
-            structured.context = context.clone();
+    /// Set a custom timestamp format using a strftime-compatible format string
+    #[must_use]
+    pub fn with_custom_timestamp(mut self, format_str: &str) -> Self {
+        self.timestamp_format = TimestampFormat::Custom(format_str.to_string());
+        self
+    }
+
+    /// Format timestamp according to configured format
+    fn format_timestamp(&self, entry: &LogEntry) -> serde_json::Value {
+        match &self.timestamp_format {
+            TimestampFormat::Unix => {
+                serde_json::Value::Number(entry.timestamp.timestamp().into())
+            }
+            TimestampFormat::UnixMillis => {
+                serde_json::Value::Number(entry.timestamp.timestamp_millis().into())
+            }
+            TimestampFormat::UnixMicros => {
+                serde_json::Value::Number(entry.timestamp.timestamp_micros().into())
+            }
+            _ => serde_json::Value::String(self.timestamp_format.format(&entry.timestamp)),
         }
-
-        structured.timestamp = entry.timestamp.timestamp_millis();
-        structured
     }
 }
 
@@ -61,12 +90,49 @@ impl Appender for JsonAppender {
     }
 
     fn append(&mut self, entry: &LogEntry) -> Result<()> {
-        let structured = self.to_structured(entry);
+        // Build JSON object with configurable timestamp format
+        let mut json_obj = serde_json::Map::new();
 
+        // Add timestamp with configured format
+        json_obj.insert("timestamp".to_string(), self.format_timestamp(entry));
+
+        // Add level
+        json_obj.insert(
+            "level".to_string(),
+            serde_json::Value::String(entry.level.to_str().to_string()),
+        );
+
+        // Add message
+        json_obj.insert(
+            "message".to_string(),
+            serde_json::Value::String(entry.message.clone()),
+        );
+
+        // Add thread info
+        json_obj.insert(
+            "thread_id".to_string(),
+            serde_json::Value::String(entry.thread_id.clone()),
+        );
+        if let Some(name) = &entry.thread_name {
+            json_obj.insert(
+                "thread_name".to_string(),
+                serde_json::Value::String(name.clone()),
+            );
+        }
+
+        // Add context fields if present
+        if let Some(context) = &entry.context {
+            for (key, value) in context.fields() {
+                json_obj.insert(key.clone(), value.to_json_value());
+            }
+        }
+
+        // Serialize to JSON
+        let json_value = serde_json::Value::Object(json_obj);
         let json = if self.pretty {
-            structured.to_json_pretty()?
+            serde_json::to_string_pretty(&json_value)?
         } else {
-            structured.to_json()?
+            serde_json::to_string(&json_value)?
         };
 
         writeln!(self.writer, "{}", json)?;

--- a/src/core/log_context.rs
+++ b/src/core/log_context.rs
@@ -27,6 +27,22 @@ impl fmt::Display for FieldValue {
     }
 }
 
+impl FieldValue {
+    /// Convert to serde_json::Value for JSON serialization
+    #[must_use]
+    pub fn to_json_value(&self) -> serde_json::Value {
+        match self {
+            FieldValue::String(s) => serde_json::Value::String(s.clone()),
+            FieldValue::Int(i) => serde_json::Value::Number((*i).into()),
+            FieldValue::Float(f) => serde_json::Number::from_f64(*f)
+                .map(serde_json::Value::Number)
+                .unwrap_or(serde_json::Value::Null),
+            FieldValue::Bool(b) => serde_json::Value::Bool(*b),
+            FieldValue::Null => serde_json::Value::Null,
+        }
+    }
+}
+
 impl From<String> for FieldValue {
     fn from(s: String) -> Self {
         FieldValue::String(s)

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -10,6 +10,7 @@ pub mod logger;
 pub mod metrics;
 pub mod overflow_policy;
 pub mod structured_entry;
+pub mod timestamp;
 
 pub use appender::Appender;
 pub use async_appender::AsyncAppender;
@@ -21,3 +22,4 @@ pub use logger::{Logger, LoggerBuilder, DEFAULT_SHUTDOWN_TIMEOUT};
 pub use metrics::LoggerMetrics;
 pub use overflow_policy::{LogPriority, OverflowCallback, OverflowPolicy};
 pub use structured_entry::{StructuredLogEntry, TracingContext};
+pub use timestamp::{FormatterConfig, TimestampFormat};

--- a/src/core/timestamp.rs
+++ b/src/core/timestamp.rs
@@ -1,0 +1,422 @@
+//! Timestamp formatting utilities
+//!
+//! Provides standardized, configurable timestamp formats for log output.
+//! Supports ISO 8601, RFC 3339, Unix timestamps, and custom formats.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::SystemTime;
+
+/// Standardized timestamp format options
+///
+/// Supports various timestamp formats commonly used in logging systems
+/// and compatible with log aggregation tools (Elasticsearch, Splunk, Loki, etc.)
+///
+/// # Examples
+///
+/// ```
+/// use rust_logger_system::core::TimestampFormat;
+/// use std::time::SystemTime;
+///
+/// let format = TimestampFormat::Iso8601;
+/// let timestamp = format.format_system_time(&SystemTime::now());
+/// // Output: "2025-01-08T10:30:45.123Z"
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TimestampFormat {
+    /// ISO 8601 with milliseconds: `2025-01-08T10:30:45.123Z`
+    ///
+    /// This is the default format, widely supported by log aggregation systems.
+    #[default]
+    Iso8601,
+
+    /// ISO 8601 with microseconds: `2025-01-08T10:30:45.123456Z`
+    ///
+    /// Provides higher precision for ordering concurrent log entries.
+    Iso8601Micros,
+
+    /// RFC 3339 format: `2025-01-08T10:30:45+00:00`
+    ///
+    /// Standard internet timestamp format with timezone offset.
+    Rfc3339,
+
+    /// Unix timestamp in seconds: `1736332245`
+    ///
+    /// Compact format, useful for systems that expect numeric timestamps.
+    Unix,
+
+    /// Unix timestamp in milliseconds: `1736332245123`
+    ///
+    /// High-precision numeric timestamp for ordering concurrent events.
+    UnixMillis,
+
+    /// Unix timestamp in microseconds: `1736332245123456`
+    ///
+    /// Maximum precision numeric timestamp.
+    UnixMicros,
+
+    /// Custom strftime format
+    ///
+    /// Allows specifying any strftime-compatible format string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rust_logger_system::core::TimestampFormat;
+    ///
+    /// // Apache log format
+    /// let format = TimestampFormat::Custom("%d/%b/%Y:%H:%M:%S %z".to_string());
+    ///
+    /// // Simple date only
+    /// let format = TimestampFormat::Custom("%Y-%m-%d".to_string());
+    /// ```
+    Custom(String),
+}
+
+impl TimestampFormat {
+    /// Format a `DateTime<Utc>` according to this format
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rust_logger_system::core::TimestampFormat;
+    /// use chrono::Utc;
+    ///
+    /// let format = TimestampFormat::Iso8601;
+    /// let timestamp = format.format(&Utc::now());
+    /// assert!(timestamp.ends_with('Z'));
+    /// ```
+    #[must_use]
+    pub fn format(&self, datetime: &DateTime<Utc>) -> String {
+        match self {
+            TimestampFormat::Iso8601 => datetime.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string(),
+            TimestampFormat::Iso8601Micros => datetime.format("%Y-%m-%dT%H:%M:%S%.6fZ").to_string(),
+            TimestampFormat::Rfc3339 => datetime.to_rfc3339(),
+            TimestampFormat::Unix => datetime.timestamp().to_string(),
+            TimestampFormat::UnixMillis => datetime.timestamp_millis().to_string(),
+            TimestampFormat::UnixMicros => datetime.timestamp_micros().to_string(),
+            TimestampFormat::Custom(format_str) => datetime.format(format_str).to_string(),
+        }
+    }
+
+    /// Format a `SystemTime` according to this format
+    ///
+    /// Convenience method that converts `SystemTime` to `DateTime<Utc>` first.
+    #[must_use]
+    pub fn format_system_time(&self, timestamp: &SystemTime) -> String {
+        let datetime: DateTime<Utc> = (*timestamp).into();
+        self.format(&datetime)
+    }
+
+    /// Check if this is a Unix-based numeric format
+    #[must_use]
+    pub fn is_numeric(&self) -> bool {
+        matches!(
+            self,
+            TimestampFormat::Unix | TimestampFormat::UnixMillis | TimestampFormat::UnixMicros
+        )
+    }
+
+    /// Get a description of this format
+    #[must_use]
+    pub fn description(&self) -> &str {
+        match self {
+            TimestampFormat::Iso8601 => "ISO 8601 with milliseconds (2025-01-08T10:30:45.123Z)",
+            TimestampFormat::Iso8601Micros => {
+                "ISO 8601 with microseconds (2025-01-08T10:30:45.123456Z)"
+            }
+            TimestampFormat::Rfc3339 => "RFC 3339 with timezone (2025-01-08T10:30:45+00:00)",
+            TimestampFormat::Unix => "Unix timestamp in seconds (1736332245)",
+            TimestampFormat::UnixMillis => "Unix timestamp in milliseconds (1736332245123)",
+            TimestampFormat::UnixMicros => "Unix timestamp in microseconds (1736332245123456)",
+            TimestampFormat::Custom(_) => "Custom strftime format",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn fixed_datetime() -> DateTime<Utc> {
+        // 2025-01-08 10:30:45.123456 UTC
+        Utc.with_ymd_and_hms(2025, 1, 8, 10, 30, 45)
+            .single()
+            .expect("valid datetime")
+            + chrono::Duration::microseconds(123456)
+    }
+
+    #[test]
+    fn test_iso8601_format() {
+        let format = TimestampFormat::Iso8601;
+        let result = format.format(&fixed_datetime());
+        assert_eq!(result, "2025-01-08T10:30:45.123Z");
+    }
+
+    #[test]
+    fn test_iso8601_micros_format() {
+        let format = TimestampFormat::Iso8601Micros;
+        let result = format.format(&fixed_datetime());
+        assert_eq!(result, "2025-01-08T10:30:45.123456Z");
+    }
+
+    #[test]
+    fn test_rfc3339_format() {
+        let format = TimestampFormat::Rfc3339;
+        let result = format.format(&fixed_datetime());
+        // RFC 3339 format includes timezone offset
+        assert!(result.starts_with("2025-01-08T10:30:45"));
+        assert!(result.contains("+00:00") || result.ends_with('Z'));
+    }
+
+    #[test]
+    fn test_unix_format() {
+        let format = TimestampFormat::Unix;
+        let result = format.format(&fixed_datetime());
+        // Should be a valid integer
+        let parsed: i64 = result.parse().expect("valid unix timestamp");
+        assert!(parsed > 0);
+    }
+
+    #[test]
+    fn test_unix_millis_format() {
+        let format = TimestampFormat::UnixMillis;
+        let result = format.format(&fixed_datetime());
+        let parsed: i64 = result.parse().expect("valid unix millis timestamp");
+        // Milliseconds should be larger than seconds
+        let unix_result: i64 = TimestampFormat::Unix
+            .format(&fixed_datetime())
+            .parse()
+            .unwrap();
+        assert!(parsed > unix_result);
+    }
+
+    #[test]
+    fn test_unix_micros_format() {
+        let format = TimestampFormat::UnixMicros;
+        let result = format.format(&fixed_datetime());
+        let parsed: i64 = result.parse().expect("valid unix micros timestamp");
+        // Microseconds should be larger than milliseconds
+        let millis_result: i64 = TimestampFormat::UnixMillis
+            .format(&fixed_datetime())
+            .parse()
+            .unwrap();
+        assert!(parsed > millis_result);
+    }
+
+    #[test]
+    fn test_custom_format() {
+        let format = TimestampFormat::Custom("%Y/%m/%d %H:%M".to_string());
+        let result = format.format(&fixed_datetime());
+        assert_eq!(result, "2025/01/08 10:30");
+    }
+
+    #[test]
+    fn test_custom_apache_format() {
+        let format = TimestampFormat::Custom("%d/%b/%Y:%H:%M:%S +0000".to_string());
+        let result = format.format(&fixed_datetime());
+        assert_eq!(result, "08/Jan/2025:10:30:45 +0000");
+    }
+
+    #[test]
+    fn test_default_is_iso8601() {
+        assert_eq!(TimestampFormat::default(), TimestampFormat::Iso8601);
+    }
+
+    #[test]
+    fn test_is_numeric() {
+        assert!(!TimestampFormat::Iso8601.is_numeric());
+        assert!(!TimestampFormat::Iso8601Micros.is_numeric());
+        assert!(!TimestampFormat::Rfc3339.is_numeric());
+        assert!(TimestampFormat::Unix.is_numeric());
+        assert!(TimestampFormat::UnixMillis.is_numeric());
+        assert!(TimestampFormat::UnixMicros.is_numeric());
+        assert!(!TimestampFormat::Custom("%Y".to_string()).is_numeric());
+    }
+
+    #[test]
+    fn test_format_system_time() {
+        let format = TimestampFormat::Iso8601;
+        let system_time = SystemTime::now();
+        let result = format.format_system_time(&system_time);
+        // Should produce a valid ISO 8601 string
+        assert!(result.ends_with('Z'));
+        assert!(result.contains('T'));
+    }
+
+    #[test]
+    fn test_serialization() {
+        let format = TimestampFormat::Iso8601;
+        let json = serde_json::to_string(&format).expect("serialize");
+        assert_eq!(json, "\"Iso8601\"");
+
+        let custom = TimestampFormat::Custom("%Y-%m-%d".to_string());
+        let json = serde_json::to_string(&custom).expect("serialize custom");
+        assert!(json.contains("Custom"));
+    }
+
+    #[test]
+    fn test_deserialization() {
+        let format: TimestampFormat =
+            serde_json::from_str("\"Iso8601\"").expect("deserialize Iso8601");
+        assert_eq!(format, TimestampFormat::Iso8601);
+
+        let format: TimestampFormat =
+            serde_json::from_str(r#"{"Custom":"%Y-%m-%d"}"#).expect("deserialize Custom");
+        assert_eq!(format, TimestampFormat::Custom("%Y-%m-%d".to_string()));
+    }
+}
+
+/// Configuration for log formatting
+///
+/// This struct holds formatting options that can be shared across appenders.
+/// It is wrapped in `Arc` for efficient sharing in multi-threaded contexts.
+///
+/// # Examples
+///
+/// ```
+/// use rust_logger_system::core::{FormatterConfig, TimestampFormat};
+///
+/// let config = FormatterConfig::new()
+///     .with_timestamp_format(TimestampFormat::Iso8601Micros)
+///     .with_level_uppercase(false);
+/// ```
+#[derive(Debug, Clone)]
+pub struct FormatterConfig {
+    /// Timestamp format for log entries
+    pub timestamp_format: TimestampFormat,
+    /// Whether to include log level in output
+    pub include_level: bool,
+    /// Whether to include thread ID in output
+    pub include_thread_id: bool,
+    /// Whether to include file location (file:line) in output
+    pub include_file_location: bool,
+    /// Whether to display log level in uppercase (ERROR vs error)
+    pub level_uppercase: bool,
+}
+
+impl Default for FormatterConfig {
+    fn default() -> Self {
+        Self {
+            timestamp_format: TimestampFormat::default(),
+            include_level: true,
+            include_thread_id: true,
+            include_file_location: false,
+            level_uppercase: true,
+        }
+    }
+}
+
+impl FormatterConfig {
+    /// Create a new formatter configuration with default values
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the timestamp format
+    #[must_use]
+    pub fn with_timestamp_format(mut self, format: TimestampFormat) -> Self {
+        self.timestamp_format = format;
+        self
+    }
+
+    /// Set whether to include log level
+    #[must_use]
+    pub fn with_include_level(mut self, include: bool) -> Self {
+        self.include_level = include;
+        self
+    }
+
+    /// Set whether to include thread ID
+    #[must_use]
+    pub fn with_include_thread_id(mut self, include: bool) -> Self {
+        self.include_thread_id = include;
+        self
+    }
+
+    /// Set whether to include file location
+    #[must_use]
+    pub fn with_include_file_location(mut self, include: bool) -> Self {
+        self.include_file_location = include;
+        self
+    }
+
+    /// Set whether log level should be uppercase
+    #[must_use]
+    pub fn with_level_uppercase(mut self, uppercase: bool) -> Self {
+        self.level_uppercase = uppercase;
+        self
+    }
+
+    /// Create a custom timestamp format
+    ///
+    /// # Arguments
+    ///
+    /// * `format_str` - A strftime-compatible format string
+    #[must_use]
+    pub fn with_custom_timestamp(mut self, format_str: &str) -> Self {
+        self.timestamp_format = TimestampFormat::Custom(format_str.to_string());
+        self
+    }
+
+    /// Wrap this config in an Arc for sharing across appenders
+    #[must_use]
+    pub fn shared(self) -> Arc<Self> {
+        Arc::new(self)
+    }
+}
+
+#[cfg(test)]
+mod formatter_config_tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = FormatterConfig::default();
+        assert_eq!(config.timestamp_format, TimestampFormat::Iso8601);
+        assert!(config.include_level);
+        assert!(config.include_thread_id);
+        assert!(!config.include_file_location);
+        assert!(config.level_uppercase);
+    }
+
+    #[test]
+    fn test_builder_pattern() {
+        let config = FormatterConfig::new()
+            .with_timestamp_format(TimestampFormat::UnixMillis)
+            .with_include_level(false)
+            .with_include_thread_id(false)
+            .with_include_file_location(true)
+            .with_level_uppercase(false);
+
+        assert_eq!(config.timestamp_format, TimestampFormat::UnixMillis);
+        assert!(!config.include_level);
+        assert!(!config.include_thread_id);
+        assert!(config.include_file_location);
+        assert!(!config.level_uppercase);
+    }
+
+    #[test]
+    fn test_custom_timestamp() {
+        let config = FormatterConfig::new().with_custom_timestamp("%Y/%m/%d");
+
+        assert_eq!(
+            config.timestamp_format,
+            TimestampFormat::Custom("%Y/%m/%d".to_string())
+        );
+    }
+
+    #[test]
+    fn test_shared_config() {
+        let config = FormatterConfig::new()
+            .with_timestamp_format(TimestampFormat::Rfc3339)
+            .shared();
+
+        // Can clone Arc cheaply
+        let config2 = Arc::clone(&config);
+        assert_eq!(config.timestamp_format, config2.timestamp_format);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,13 +17,15 @@ pub mod macros;
 pub mod prelude {
     pub use crate::appenders::{ConsoleAppender, FileAppender};
     pub use crate::core::{
-        Appender, LogEntry, LogLevel, Logger, LoggerBuilder, LoggerError, LoggerMetrics,
-        LogPriority, OverflowCallback, OverflowPolicy, Result, DEFAULT_SHUTDOWN_TIMEOUT,
+        Appender, FormatterConfig, LogEntry, LogLevel, Logger, LoggerBuilder, LoggerError,
+        LoggerMetrics, LogPriority, OverflowCallback, OverflowPolicy, Result, TimestampFormat,
+        DEFAULT_SHUTDOWN_TIMEOUT,
     };
 }
 
 pub use appenders::{ConsoleAppender, FileAppender};
 pub use core::{
-    Appender, LogEntry, LogLevel, Logger, LoggerBuilder, LoggerError, LoggerMetrics, LogPriority,
-    OverflowCallback, OverflowPolicy, Result, DEFAULT_SHUTDOWN_TIMEOUT,
+    Appender, FormatterConfig, LogEntry, LogLevel, Logger, LoggerBuilder, LoggerError,
+    LoggerMetrics, LogPriority, OverflowCallback, OverflowPolicy, Result, TimestampFormat,
+    DEFAULT_SHUTDOWN_TIMEOUT,
 };


### PR DESCRIPTION
## Summary

- Add `TimestampFormat` enum with ISO 8601, RFC 3339, Unix timestamp variants
- Add `FormatterConfig` struct for shared formatting configuration
- Update all appenders (Console, File, RotatingFile, Json) to support configurable timestamp formats
- JSON output now supports both string (ISO 8601) and numeric (Unix) timestamp formats

## Changes

| File | Description |
|------|-------------|
| `src/core/timestamp.rs` | New module with `TimestampFormat` enum and `FormatterConfig` |
| `src/appenders/console.rs` | Add `with_timestamp_format()` method |
| `src/appenders/file.rs` | Add `with_timestamp_format()` method |
| `src/appenders/rotating_file.rs` | Add `with_timestamp_format()` method |
| `src/appenders/json.rs` | Add configurable timestamp (string or number based on format) |
| `src/core/log_context.rs` | Add `to_json_value()` for `FieldValue` |
| `tests/integration_tests.rs` | Add timestamp format integration tests |
| `IMPROVEMENTS.md` | Mark Issue #2 as resolved |

## Example Usage

```rust
use rust_logger_system::prelude::*;
use rust_logger_system::TimestampFormat;

// ISO 8601 format (default)
let logger = Logger::builder()
    .appender(ConsoleAppender::new().with_timestamp_format(TimestampFormat::Iso8601))
    .build();

// Unix milliseconds for high-precision ordering
let logger = Logger::builder()
    .appender(FileAppender::new("/var/log/app.log")?.with_timestamp_format(TimestampFormat::UnixMillis))
    .build();

// Custom format for legacy compatibility
let logger = Logger::builder()
    .appender(ConsoleAppender::new().with_custom_timestamp("%d/%b/%Y:%H:%M:%S %z"))
    .build();
```

## Output Examples

| Format | Example Output |
|--------|---------------|
| Iso8601 | `2025-01-08T10:30:45.123Z` |
| Iso8601Micros | `2025-01-08T10:30:45.123456Z` |
| Rfc3339 | `2025-01-08T10:30:45+00:00` |
| Unix | `1736332245` |
| UnixMillis | `1736332245123` |
| Custom | `08/Jan/2025:10:30:45 +0000` |

## Test plan

- [x] Unit tests for `TimestampFormat` enum (all variants)
- [x] Unit tests for `FormatterConfig` struct
- [x] Integration tests for file appender with different formats
- [x] Integration tests for JSON appender (string vs number timestamps)
- [x] Integration tests for multiple appenders with different formats
- [x] All existing tests pass
- [x] Clippy passes with no warnings
- [x] Documentation builds successfully

Closes #2