### PR TITLE
feat(rotation): implement log rotation strategies

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -297,21 +297,19 @@ impl Formatter {
 **Priority**: Medium
 **Estimated Effort**: Small (2-3 days)
 
-### 3. No Log Rotation Strategy
+### 3. No Log Rotation Strategy ✅ RESOLVED
 
 **Issue**: File appender lacks built-in log rotation, which can lead to unbounded disk usage and make log management difficult in long-running applications.
 
-**Current State**:
-```rust
-// src/appenders/file.rs
-pub struct FileAppender {
-    file: File,
-    path: PathBuf,
-    // No rotation support!
-}
-```
+**Status**: **RESOLVED** - Implemented in `src/appenders/rotating_file.rs`
 
-**Impact**:
+**Solution Implemented**:
+- Added `RotationStrategy` enum with support for Size, Time, Daily, Hourly, Hybrid, and Never strategies
+- Updated `RotatingFileAppender` to support all rotation strategies with `last_rotation` timestamp tracking
+- Added configurable backup retention and optional gzip compression
+- Comprehensive unit tests for all rotation strategies
+
+**Previous Impact** (now resolved):
 - Log files can grow indefinitely
 - Disk space exhaustion in production
 - Difficult to manage and archive old logs
@@ -714,10 +712,10 @@ let logger = Logger::with_config(LoggerConfig {
 - [x] Add structured logging support (LogContext with FieldValue)
 - [x] Update documentation
 
-### Phase 3: Production Features (Sprint 3)
-- [ ] Implement log rotation
-- [ ] Add compression support
-- [ ] Create rotation tests
+### Phase 3: Production Features (Sprint 3) ✅ COMPLETED
+- [x] Implement log rotation (RotationStrategy enum with Size, Time, Daily, Hourly, Hybrid, Never)
+- [x] Add compression support (gzip compression for rotated files)
+- [x] Create rotation tests (comprehensive unit tests for all strategies)
 - [ ] Add operations guide
 
 ### Phase 4: Advanced Features (Sprint 4)

--- a/src/appenders/mod.rs
+++ b/src/appenders/mod.rs
@@ -13,7 +13,7 @@ pub use console::ConsoleAppender;
 pub use file::FileAppender;
 pub use json::JsonAppender;
 pub use network::NetworkAppender;
-pub use rotating_file::{RotatingFileAppender, RotationPolicy};
+pub use rotating_file::{RotatingFileAppender, RotationPolicy, RotationStrategy};
 
 #[cfg(feature = "async-appenders")]
 pub use async_file::AsyncFileAppender;


### PR DESCRIPTION
## Summary

- Add `RotationStrategy` enum with multiple rotation strategies
- Update `RotatingFileAppender` to support time-based rotation
- Add `last_rotation` timestamp tracking
- Add comprehensive unit tests for all strategies

## Changes

### New Rotation Strategies

| Strategy | Description |
|----------|-------------|
| `Size` | Rotate when file exceeds specified bytes (existing behavior) |
| `Time` | Rotate at specified time intervals |
| `Daily` | Rotate daily at specified hour (0-23) |
| `Hourly` | Rotate every hour |
| `Hybrid` | Rotate on size OR time, whichever comes first |
| `Never` | Disable rotation (for external rotation management) |

### New API

```rust
// Size-based (default)
let policy = RotationPolicy::new()
    .with_max_size(100 * 1024 * 1024)
    .with_max_backups(7)
    .with_compression(true);

// Daily at midnight
let policy = RotationPolicy::new()
    .with_strategy(RotationStrategy::Daily { hour: 0 })
    .with_max_backups(30);

// Hybrid
let policy = RotationPolicy::new()
    .with_strategy(RotationStrategy::Hybrid {
        max_bytes: 50 * 1024 * 1024,
        interval: Duration::from_secs(24 * 3600),
    });
```

### New Methods

- `RotatingFileAppender::last_rotation()` - Get last rotation timestamp
- `RotatingFileAppender::strategy()` - Get current rotation strategy
- `RotationPolicy::max_file_size()` - Get max size if applicable

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (118 unit tests + 33 doc tests)
- [x] `cargo clippy` passes with no warnings
- [x] New unit tests for all rotation strategies
- [x] Documentation updated (README.md, IMPROVEMENTS.md)

## Closes

Closes #3